### PR TITLE
added schema parse form string

### DIFF
--- a/src/main/kotlin/net/pwall/json/schema/JSONSchema.kt
+++ b/src/main/kotlin/net/pwall/json/schema/JSONSchema.kt
@@ -272,6 +272,8 @@ sealed class JSONSchema(
 
         fun parse(file: File): JSONSchema = parser.parse(file)
 
+        fun parse(string: String): JSONSchema = parser.parse(string)
+
         fun allOf(uri: URI?, location: JSONPointer, array: List<JSONSchema>) = AllOfSchema(uri, location, array)
 
         fun anyOf(uri: URI?, location: JSONPointer, array: List<JSONSchema>) = AnyOfSchema(uri, location, array)

--- a/src/main/kotlin/net/pwall/json/schema/parser/JSONReader.kt
+++ b/src/main/kotlin/net/pwall/json/schema/parser/JSONReader.kt
@@ -119,7 +119,6 @@ class JSONReader(val uriResolver: (URI) -> InputStream?) {
     }
 
     fun readJSON(string: String): JSONValue {
-
         return JSON.parse(string)
     }
 

--- a/src/main/kotlin/net/pwall/json/schema/parser/JSONReader.kt
+++ b/src/main/kotlin/net/pwall/json/schema/parser/JSONReader.kt
@@ -118,6 +118,11 @@ class JSONReader(val uriResolver: (URI) -> InputStream?) {
         }
     }
 
+    fun readJSON(string: String): JSONValue {
+
+        return JSON.parse(string)
+    }
+
     fun readJSON(uri: URI): JSONValue {
         return jsonCache[uri] ?: try {
             val inputStream = uriResolver(uri) ?: throw JSONSchemaException("Can't resolve name - $uri")

--- a/src/main/kotlin/net/pwall/json/schema/parser/Parser.kt
+++ b/src/main/kotlin/net/pwall/json/schema/parser/Parser.kt
@@ -131,7 +131,7 @@ class Parser(var options: Options = Options(), uriResolver: (URI) -> InputStream
 
     fun parse(string: String): JSONSchema {
         val json = jsonReader.readJSON(string)
-        return parse(json,null)
+        return parse(json, null)
     }
 
     private fun parse(json: JSONValue, uri: URI?): JSONSchema {

--- a/src/main/kotlin/net/pwall/json/schema/parser/Parser.kt
+++ b/src/main/kotlin/net/pwall/json/schema/parser/Parser.kt
@@ -129,7 +129,12 @@ class Parser(var options: Options = Options(), uriResolver: (URI) -> InputStream
         return parse(json, uri)
     }
 
-    private fun parse(json: JSONValue, uri: URI): JSONSchema {
+    fun parse(string: String): JSONSchema {
+        val json = jsonReader.readJSON(string)
+        return parse(json,null)
+    }
+
+    private fun parse(json: JSONValue, uri: URI?): JSONSchema {
         val schemaVersion = (json as? JSONMapping<*>)?.getStringOrNull(JSONPointer.root.child("\$schema"))
         val pointer = JSONPointer.root
         return when (schemaVersion) {


### PR DESCRIPTION
Now it is no way to initialize the schema other than writing the resource to a file. I think adding a schema parser for the string is also a good idea for one who has a lot of schemas to maintain.

Please review and edit this feature for the community.