### PR TITLE
Added support for nested JAR paths

### DIFF
--- a/src/main/kotlin/net/pwall/json/schema/parser/JSONReader.kt
+++ b/src/main/kotlin/net/pwall/json/schema/parser/JSONReader.kt
@@ -213,7 +213,7 @@ class JSONReader(val uriResolver: (URI) -> InputStream?) {
 
         fun URI.extendedPath(): String = when (scheme) {
             "file", "http", "https" -> path
-            "jar" -> schemeSpecificPart.substringBefore("?").substringAfter("!")
+            "jar", "nested" -> schemeSpecificPart.substringBefore("?").substringAfter("!")
             else -> "UNKNOWN"
         }
 


### PR DESCRIPTION
As of Spring 3.2, the default loader has moved form standard "jar" paths to "nested". This is meant to be a drop in replacement for standard Jar path loading.

https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-3.2-Release-Notes#nested-jar-support

Without this change, using the default loader would result in an exception like: 

```
Caused by: net.pwall.json.schema.JSONSchemaException: Error reading schema file - nested:/app/some-service.jar/!BOOT-INF/classes/!/library/some-schema.yaml
```

Simply adds `nested` as a supported scheme, leveraging the existing `jar` support.