### PR TITLE
Implemented parsing of recursive $ref

### DIFF
--- a/src/main/kotlin/net/pwall/json/schema/JSONSchema.kt
+++ b/src/main/kotlin/net/pwall/json/schema/JSONSchema.kt
@@ -132,6 +132,9 @@ sealed class JSONSchema(
 
     override fun hashCode(): Int = uri.hashCode() xor location.hashCode()
 
+    override fun toString() =
+        "${this::class.java.simpleName}(uri=$uri, location=$location, description=$description, title=$title)"
+
     @Suppress("EqualsOrHashCode")
     class True(uri: URI?, location: JSONPointer) : JSONSchema(uri, location) {
 
@@ -266,6 +269,9 @@ sealed class JSONSchema(
 
         override fun hashCode(): Int = super.hashCode() xor schemaVersion.hashCode() xor title.hashCode() xor
                 description.hashCode() xor children.hashCode()
+
+        override fun toString() = "General(uri=$uri, location=$location, " +
+                "schemaVersion='$schemaVersion', title=$title, description=$description, children=$children)}"
 
     }
 

--- a/src/main/kotlin/net/pwall/json/schema/subschema/RefSchema.kt
+++ b/src/main/kotlin/net/pwall/json/schema/subschema/RefSchema.kt
@@ -30,11 +30,20 @@ import java.net.URI
 import net.pwall.json.JSONValue
 import net.pwall.json.pointer.JSONPointer
 import net.pwall.json.schema.JSONSchema
+import net.pwall.json.schema.JSONSchemaException
 import net.pwall.json.schema.output.BasicOutput
 import net.pwall.json.schema.output.DetailedOutput
 
-class RefSchema(uri: URI?, location: JSONPointer, val target: JSONSchema, val fragment: String?) :
+class RefSchema(uri: URI?, location: JSONPointer, target: JSONSchema, val fragment: String?) :
         JSONSchema.SubSchema(uri, location) {
+
+    var target: JSONSchema = target
+        set(value) {
+            if (field !is False) {
+                throw JSONSchemaException("Modification of resolved RefSchema target is prohibited")
+            }
+            field = value
+        }
 
     override fun childLocation(pointer: JSONPointer): JSONPointer = pointer.child("\$ref")
 
@@ -57,5 +66,25 @@ class RefSchema(uri: URI?, location: JSONPointer, val target: JSONSchema, val fr
             other is RefSchema && super.equals(other) && target == other.target
 
     override fun hashCode(): Int = super.hashCode() xor target.hashCode()
+
+    private var toStringVisiting = false
+
+    /**
+     * toString() implementation with loop protection.
+     * The var "toStringVisiting" is set to true before construction of the resulting String.
+     * When it is found to be already set, the contents will not be evaluated recursively.
+     */
+    override fun toString(): String {
+        return if (toStringVisiting) {
+            "RefSchema(<recursive access>)"
+        } else {
+            try {
+                toStringVisiting = true
+                "RefSchema(uri=$uri, location=$location, fragment=$fragment, target=$target)"
+            } finally {
+                toStringVisiting = false
+            }
+        }
+    }
 
 }


### PR DESCRIPTION
Implemented parsing of recursive/cyclic `$ref`s and added some `toString()` implementations to improve debugging.

This will break `json-kotlin-schema-codegen` up to and including version 0.108, since that project is not prepared for cyclic schema referencing yet.